### PR TITLE
#12 add clear filters action

### DIFF
--- a/src/nessie_platform/actions/__init__.py
+++ b/src/nessie_platform/actions/__init__.py
@@ -1,4 +1,4 @@
-from .filters import apply_filters, add_filter, remove_filter, search
+from .filters import apply_filters, add_filter, clear_filters, remove_filter, search
 from .workspaces import switch_workspace, close_workspace, open_workspace
 from .visualizers import change_visualizer
 from .console import add_message, clear_console
@@ -11,6 +11,7 @@ def platform_plugin():
         constants.APPLY_FILTERS: apply_filters,
         constants.ADD_FILTER: add_filter,
         constants.REMOVE_FILTER: remove_filter,
+        constants.CLEAR_FILTERS: clear_filters,
         constants.SWITCH_WORKSPACE: switch_workspace,
         constants.OPEN_WORKSPACE: open_workspace,
         constants.CLOSE_WORKSPACE: close_workspace,

--- a/src/nessie_platform/plugin_manager.py
+++ b/src/nessie_platform/plugin_manager.py
@@ -100,7 +100,7 @@ class PluginManager:
         actions = [action_name] if action_name else self.plugins
         return [plugin for action in actions for plugin in self.plugins.get(action, [])]
 
-    def get_plugin(self, action_name: str, prioritization: bool = True) -> Plugin:
+    def get_plugin(self, action_name: str, prioritization: bool = False) -> Plugin:
         """
         Get a plugin for the given action name.
         If prioritization is enabled, use the prioritization plugin to select the best plugin.


### PR DESCRIPTION
Closes #12 

This pull request introduces a new `clear_filters` action to the platform and adjusts the plugin retrieval logic. The main changes focus on enhancing filter management and modifying the default behavior for plugin prioritization.

**Filter management improvements:**

* Added the `clear_filters` function to the `src/nessie_platform/actions/__init__.py` exports and registered it in the `platform_plugin` action mapping, enabling the platform to clear all applied filters. [[1]](diffhunk://#diff-dca7f24ff6ba01a0d15e971b7880ee06f92eec9caea37d0da0a3fccedcbbfa76L1-R1) [[2]](diffhunk://#diff-dca7f24ff6ba01a0d15e971b7880ee06f92eec9caea37d0da0a3fccedcbbfa76R14)

**Plugin management changes:**

* Changed the default value of the `prioritization` parameter in the `get_plugin` method of `PluginManager` from `True` to `False`, altering the default plugin selection behavior.